### PR TITLE
Add wp_posts and wp_postmeta relationships to docs

### DIFF
--- a/docs/db/relations-post-postmeta.md
+++ b/docs/db/relations-post-postmeta.md
@@ -1,0 +1,119 @@
+## Структура таблиц
+
+### Таблица `wp_posts`
+
+| Поле             | Тип данных   | Описание                 |
+|------------------|--------------|---------------------------|
+| `ID`             | INT          | Уникальный идентификатор  |
+| `post_author`    | BIGINT       | Автор поста              |
+| `post_date`      | DATETIME     | Дата публикации          |
+| `post_content`   | LONGTEXT     | Содержимое поста         |
+| `post_title`     | TEXT         | Заголовок поста          |
+| `post_excerpt`   | TEXT         | Краткое содержание       |
+| `post_status`    | VARCHAR(20)  | Статус поста             |
+| `comment_status` | VARCHAR(20)  | Статус комментариев      |
+| `ping_status`    | VARCHAR(20)  | Статус пингов            |
+| `post_password`  | VARCHAR(255) | Пароль для доступа       |
+| `post_name`      | VARCHAR(200) | ЧПУ (человекопонятный URL)|
+| `to_ping`        | TEXT         | Список ссылок для пинга   |
+| `pinged`         | TEXT         | Полученные пинги         |
+| `post_modified`  | DATETIME     | Дата последнего изменения|
+| `post_modified_gmt` | DATETIME  | Время последнего изменения (GMT) |
+| `post_content_filtered` | LONGTEXT | Отфильтрованное содержимое   |
+| `post_parent`    | BIGINT       | Родительский пост        |
+| `guid`           | VARCHAR(255) | Глобально уникальный идентификатор |
+| `menu_order`     | INT          | Порядок сортировки       |
+| `post_type`      | VARCHAR(20)  | Тип поста               |
+| `post_mime_type` | VARCHAR(100) | MIME-тип вложения        |
+| `comment_count`  | BIGINT       | Количество комментариев  |
+
+### Таблица `wp_postmeta`
+
+| Поле       | Тип данных | Описание                |
+|------------|------------|--------------------------|
+| `meta_id`  | BIGINT     | Уникальный идентификатор |
+| `post_id`  | BIGINT     | Идентификатор поста      |
+| `meta_key` | VARCHAR(255) | Ключ метаданных         |
+| `meta_value` | LONGTEXT | Значение метаданных     |
+
+## Связь между таблицами
+
+Таблицы `wp_posts` и `wp_postmeta` связаны через поле `post_id` в таблице `wp_postmeta`, которое соответствует полю `ID` в таблице `wp_posts`. Эта связь позволяет хранить произвольные метаданные для каждого поста в отдельной таблице.
+
+```mermaid
+erDiagram
+    wp_posts ||--o{ wp_postmeta : "связана с"
+    wp_posts {
+        INT ID
+        VARCHAR(20) post_type
+        TEXT post_title
+    }
+    wp_postmeta {
+        BIGINT post_id
+        VARCHAR(255) meta_key
+        LONGTEXT meta_value
+    }
+```
+
+
+```mysql
+/*
+The query selects ID, date, type, title, metadata key, and metadata value of posts with types 'event' and 'program' sorted by ID.
+Запрос выбирает идентификатор, дату, тип, заголовок, ключ метаданных и значение метаданных постов с типами 'event' и 'program', отсортированных по идентификатору.
+*/
+
+SELECT p.ID, p.post_date, p.post_type, p.post_title, pm.meta_key, pm.meta_value
+FROM `wp_posts` AS p
+JOIN `wp_postmeta` AS pm ON p.ID = pm.post_id
+WHERE p.post_type IN ('event', 'program')
+ORDER BY p.ID;
+```
+
+---
+
+```mysql
+/*
+The query selects ID, date, type, title, metadata key, and value from posts joined with postmeta based on their IDs.
+Запрос выбирает идентификатор, дату, тип, заголовок, ключ метаданных и значение из постов, объединенных с метаданными по их идентификаторам.
+*/
+
+SELECT p.ID, p.post_date, p.post_type, p.post_title, pm.meta_key, pm.meta_value
+FROM `wp_posts` AS p
+JOIN `wp_postmeta` AS pm ON p.ID = pm.post_id
+WHERE p.ID = 50;
+```
+
+---
+The query results contain information about the event with ID 50, including the creation date, post type ("event"), title ("Test Event"), and various metadata such as the date of the event, related programs, and editing data.
+
+Результаты запроса содержат информацию о событии с ID 50, включая дату создания, тип поста ("event"), заголовок ("Test Event") и различные метаданные, такие как дата события, связанные программы и данные о редактировании.
+
+| ID | post_date           | post_type | post_title | meta_key          | meta_value          |
+|----|---------------------|-----------|------------|-------------------|---------------------|
+| 50 | 2025-01-15 06:24:45 | event     | Test Event | _edit_lock        | 1737108600:1        |
+| 50 | 2025-01-15 06:24:45 | event     | Test Event | footnotes         |                     |
+| 50 | 2025-01-15 06:24:45 | event     | Test Event | _edit_last        | 1                   |
+| 50 | 2025-01-15 06:24:45 | event     | Test Event | event_date        | 2025-01-27 15:00:00 |
+| 50 | 2025-01-15 06:24:45 | event     | Test Event | _event_date       | field_6787a20c38e63 |
+| 50 | 2025-01-15 06:24:45 | event     | Test Event | related_programs  | a:1:{i:0;s:2:"82";} |
+| 50 | 2025-01-15 06:24:45 | event     | Test Event | _related_programs | field_6789f9b0d346c |
+
+---
+
+1. An event with ID 50, created on January 15, 2025, has an edit lock.
+2. The same event does not contain a footnote.
+3. The last edit of the event was made by a user with ID 1.
+4. The date of the event is January 27, 2025 at 15:00.
+5. The date meta field of the event.
+6. Associated program with ID 82.
+7. Meta field of related programs.
+
+---
+
+1. Событие с ID 50, созданное 15 января 2025 года, имеет блокировку редактирования.
+2. То же событие не содержит сноски.
+3. Последнее редактирование события было выполнено пользователем с ID 1.
+4. Дата проведения события – 27 января 2025 года в 15:00.
+5. Метаполе даты события.
+6. Связанная программа с ID 82.
+7. Метаполе связанных программ.

--- a/docs/db/table-postmeta.md
+++ b/docs/db/table-postmeta.md
@@ -1,0 +1,8 @@
+# prefix_postmeta
+
+| Field      | Type            | Null | Key | Default | Extra          |
++------------+-----------------+------+-----+---------+----------------+
+| meta_id    | bigint unsigned | NO   | PRI | NULL    | auto_increment |
+| post_id    | bigint unsigned | NO   | MUL | 0       |                |
+| meta_key   | varchar(255)    | YES  | MUL | NULL    |                |
+| meta_value | longtext        | YES  |     | NULL    |                |

--- a/docs/db/table-posts.md
+++ b/docs/db/table-posts.md
@@ -1,0 +1,50 @@
+# prefix_posts
+
+| Field                 | Type            | Null | Key | Default             | Extra          |
+|-----------------------|-----------------|------|-----|---------------------|----------------|
+| ID                    | bigint unsigned | NO   | PRI | NULL                | auto_increment |
+| post_author           | bigint unsigned | NO   | MUL | 0                   |                |
+| post_date             | datetime        | NO   |     | 0000-00-00 00:00:00 |                |
+| post_date_gmt         | datetime        | NO   |     | 0000-00-00 00:00:00 |                |
+| post_content          | longtext        | NO   |     | NULL                |                |
+| post_title            | text            | NO   |     | NULL                |                |
+| post_excerpt          | text            | NO   |     | NULL                |                |
+| post_status           | varchar(20)     | NO   |     | publish             |                |
+| comment_status        | varchar(20)     | NO   |     | open                |                |
+| ping_status           | varchar(20)     | NO   |     | open                |                |
+| post_password         | varchar(255)    | NO   |     |                     |                |
+| post_name             | varchar(200)    | NO   | MUL |                     |                |
+| to_ping               | text            | NO   |     | NULL                |                |
+| pinged                | text            | NO   |     | NULL                |                |
+| post_modified         | datetime        | NO   |     | 0000-00-00 00:00:00 |                |
+| post_modified_gmt     | datetime        | NO   |     | 0000-00-00 00:00:00 |                |
+| post_content_filtered | longtext        | NO   |     | NULL                |                |
+| post_parent           | bigint unsigned | NO   | MUL | 0                   |                |
+| guid                  | varchar(255)    | NO   |     |                     |                |
+| menu_order            | int             | NO   |     | 0                   |                |
+| post_type             | varchar(20)     | NO   | MUL | post                |                |
+| post_mime_type        | varchar(100)    | NO   |     |                     |                |
+| comment_count         | bigint          | NO   |     | 0                   |                |
+
+
+# MySQL queries 
+
+```mysql
+/* 
+The query selects all records from the `wp_posts` table where the post type (`post_type`) is equal to `'event'`.
+Запрос выбирает все записи из таблицы `wp_posts`, у которых тип поста (`post_type`) равен `'event'`.
+*/
+
+SELECT * FROM `wp_posts` WHERE post_type = 'event';
+```
+
+---
+
+```
+/*
+This query selects all records from the `wp_posts` table where the post type (`post_type`) is either `'event'` or `'program'`.
+Данный запрос выбирает все записи из таблицы `wp_posts`, у которых тип поста (`post_type`) равен `'event'` или `'program'`.
+*/
+
+SELECT * FROM `wp_posts` WHERE post_type IN ('event', 'program');
+```


### PR DESCRIPTION
Document database table relationships between wp_posts and wp_postmeta, facilitating query optimization and data integrity.