### PR TITLE
Set global WP_MAIL_FROM constant

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -157,3 +157,7 @@ function change_login_logo()
 add_action('wp_mail_failed', function ($error) {
   App\Logging\MailErrorLogger::logToStandardFile($error);
 });
+
+add_filter('wp_mail_from', function ($email) {
+  return WP_MAIL_FROM;
+});


### PR DESCRIPTION
Define WP_MAIL_FROM to override default sender address, providing consistent branding and deliverability improvements.