### PR TITLE
Add Autoprefixer dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "resolve-url-loader": "^4.0.0",
     "sass": "^1.41.1",
     "sass-loader": "^12.1.0"
+  },
+  "dependencies": {
+    "autoprefixer": "10.4.5"
   }
 }


### PR DESCRIPTION
Install Autoprefixer v10.4.5, automating vendor prefixing for improved cross-browser compatibility.